### PR TITLE
unix fix : using mktemp has different behaviour on OSX and Linux

### DIFF
--- a/unix/mutool
+++ b/unix/mutool
@@ -94,7 +94,17 @@ if [ -z "$FILES" ]; then
   exit 1
 fi
 
-TEMP_DIR=`mktemp -d`
+UNAME=$(uname -s)
+
+case $UNAME in
+    'Darwin')
+        TEMP_DIR=`mktemp -dt arduino_build`
+        ;;
+    'Linux')
+        TEMP_DIR=`mktemp -dt arduino_build.XXXXXXX`
+        ;;
+esac
+
 TEMP_FILE="output.hex"
 echo "merging hex files..."
 $MERGE_TOOL --merge $FILES_STR_CMD --output "$TEMP_DIR/$TEMP_FILE" --quiet


### PR DESCRIPTION
**mktemp** is a BSD tool under OSX while is a GNU tool under Linux. For this reason it should be invoked with the right command line arguments on each system.